### PR TITLE
Added data store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "fh-wfm-store",
-  "version": "1.0.0",
-  "description": "",
-  "main": "lib/store.js",
+  "version": "0.1.0",
+  "description": "Storage API for Raincathcer Modules",
+  "main": "cloud/StorageEngine.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
-    "waterline": "^0.11.4",
-    "lodash": "^4.16.4"
+    "lodash": "^4.16.4",
+    "q": "^1.4.1",
+    "waterline": "^0.11.4"
   }
 }

--- a/server/DataStore.js
+++ b/server/DataStore.js
@@ -1,0 +1,118 @@
+var Waterline = require('waterline');
+var q = require('q');
+var _ = require('lodash');
+
+function DataStore(mediator, schema, datasetId, topicPrefix, topicConfig) {
+  this.mediator = mediator;
+  this.topicPrefix = topicPrefix || "";
+  this.datasetId = datasetId;
+  this.topic = {};
+  this.subscription = {};
+  this.schema = schema;
+  this.collection = Waterline.Collection.extend(schema);
+  this.topicConfig = topicConfig;
+}
+
+DataStore.prototype.generateCustomTopics = function() {
+  var self = this;
+
+
+  _.each(this.topicConfig, function(topicFunc, topic) {
+    self.mediator.subscribe(topic, function() {
+      topicFunc(self.initialisedCollection).then(function(){
+        self.mediator.publish('done:' + topic);
+      });
+    });
+  });
+};
+
+/**
+ * Registering subscribers for all CRUDL mediator topics.
+ */
+DataStore.prototype.registerSubscribers = function () {
+  var self = this;
+  var topicPrefix = this.topicPrefix;
+
+  self.generateCustomTopics();
+
+  self.topic.create = "wfm:" + topicPrefix + self.datasetId + ':create';
+  console.log('Subscribing to mediator topic:', self.topic.create);
+  self.subscription.create = self.mediator.subscribe(self.topic.create, function(object, ts) {
+    ts = ts || Date.now();
+    console.log("** Creating ", self.topic.create, object, ts);
+    self.create(object, ts).then(function(object) {
+      console.log("** Finish Creating ", self.topic.create, object, ts);
+      self.mediator.publish('done:' + self.topic.create + ':' + ts, object);
+    });
+  });
+
+  self.topic.load = "wfm:" + topicPrefix + self.datasetId + ':read';
+  console.log('Subscribing to mediator topic:', self.topic.load);
+  self.subscription.load = self.mediator.subscribe(self.topic.load, function(id) {
+    self.read(id).then(function(object) {
+      self.mediator.publish('done:' + self.topic.load + ':' + id, object);
+    });
+  });
+
+  self.topic.save = "wfm:" + topicPrefix + self.datasetId + ':update';
+  console.log('Subscribing to mediator topic:', self.topic.save);
+  self.subscription.save = self.mediator.subscribe(self.topic.save, function(object) {
+    self.update(object).then(function(object) {
+      self.mediator.publish('done:' + self.topic.save + ':' + object.id, object);
+    });
+  });
+
+  self.topic.delete = "wfm:" + topicPrefix + self.datasetId + ':delete';
+  console.log('Subscribing to mediator topic:', self.topic.delete);
+  self.subscription.delete = self.mediator.subscribe(self.topic.delete, function(object) {
+    self.delete(object).then(function(object) {
+      self.mediator.publish('done:' + self.topic.delete + ':' + object.id, object);
+    });
+  });
+
+  self.topic.list = "wfm:" + topicPrefix + self.datasetId + ':list';
+  console.log('Subscribing to mediator topic:', self.topic.list);
+  self.subscription.list = self.mediator.subscribe(self.topic.list, function(queryParams) {
+    var filter = queryParams && queryParams.filter || {};
+    self.list(filter).then(function(list) {
+      self.mediator.publish('done:' + self.topic.list, list);
+    });
+  });
+};
+
+DataStore.prototype.setInitialisedCollection = function(initialisedCollection) {
+  this.initialisedCollection = initialisedCollection;
+};
+
+DataStore.prototype.create = function(dataToCreate) {
+  return this.initialisedCollection.create(dataToCreate);
+};
+
+DataStore.prototype.update = function(dataToUpdate) {
+  return this.initialisedCollection.update(dataToUpdate.id, dataToUpdate);
+};
+
+DataStore.prototype.list = function() {
+  return this.initialisedCollection.find();
+};
+
+DataStore.prototype.delete = function(objectToDelete) {
+  return this.initialisedCollection.destroy(objectToDelete.id);
+};
+
+DataStore.prototype.read = function(id) {
+  return this.initialisedCollection.findOne(id);
+};
+
+/**
+ * Un-subscribing from all mediator topics related to this mongo data store.
+ */
+DataStore.prototype.unsubscribe = function() {
+  this.mediator.remove(this.topic.list, this.subscription.list.id);
+  this.mediator.remove(this.topic.load, this.subscription.load.id);
+  this.mediator.remove(this.topic.save, this.subscription.save.id);
+  this.mediator.remove(this.topic.create, this.subscription.create.id);
+  this.mediator.remove(this.topic.delete, this.subscription.delete.id);
+};
+
+module.exports = DataStore;

--- a/server/StorageEngine.js
+++ b/server/StorageEngine.js
@@ -1,0 +1,79 @@
+var DataStore = require('./DataStore');
+var Waterline = require('waterline');
+var _ = require('lodash');
+
+function StorageEngine(mediator) {
+  var self = this;
+  this.mediator = mediator;
+  this.dataSets = {};
+  //Storage is initialised, we can use.
+  //TODO, This could be nicer..
+  this.mediator.once('wfm:storage:initialise', function(config) {
+    console.log("Initialising Storage");
+    self.initialise(config);
+  });
+
+  //When the application closes, we close the subscribers.
+  this.mediator.once('wfm:application:close', function() {
+    self.unsubscribeDataSetSubscribers();
+  });
+}
+
+StorageEngine.prototype.addDataSet = function (schema, datasetId, topicPrefix, topicConfig) {
+  console.log("Adding Data Set");
+  var dataSet = new DataStore(this.mediator, schema, datasetId, topicPrefix, topicConfig);
+
+  //Storing the data sets.
+  this.dataSets[datasetId] = dataSet;
+};
+
+StorageEngine.prototype.initialise = function(config) {
+  var self = this;
+  console.log("Initialising StorageEngine");
+  this.waterline = new Waterline();
+
+  //Loading Collections
+  _.each(this.dataSets, function(dataSet) {
+    self.waterline.loadCollection(dataSet.collection);
+  });
+
+  console.log("Initialising Waterline");
+  this.waterline.initialize(config, function(err, ontology) {
+    console.log("Waterline initialised", err, ontology);
+    if(err) {
+      self.mediator.publish('error:storage:initialise', err);
+    } else {
+      _.each(self.dataSets, function (dataSet) {
+        //Storage is ready, set the collection
+        var dataSetCollection = _.find(ontology.collections, function(initialisedCollection, name) {
+          console.log("**** collections", name, dataSet.schema.identity, initialisedCollection);
+          return name === dataSet.schema.identity;
+        });
+
+        console.log("*** dataSetCollection", dataSetCollection);
+
+        dataSet.setInitialisedCollection(dataSetCollection);
+      });
+
+      self.registerDataSetSubscribers();
+      //Finished storage initialsation.
+      self.mediator.publish('done:wfm:storage:initialise');
+    }
+
+  });
+};
+
+
+StorageEngine.prototype.registerDataSetSubscribers = function( ) {
+  _.each(this.dataSets, function (dataSet) {
+    dataSet.registerSubscribers();
+  });
+};
+
+StorageEngine.prototype.unsubscribeDataSetSubscribers = function () {
+  _.each(this.dataSets, function (dataSet) {
+    dataSet.unsubscribe();
+  });
+};
+
+module.exports = StorageEngine;


### PR DESCRIPTION
# Motivation

Raincatcher modules need to have the ability to store data in different back ends (e.g. MongoDB, Mysql etc)

Waterline (https://github.com/balderdashy/waterline-docs) provides an API to be able to save data to multiple back ends with a similar API.

# Changes

- Added a StorageEngine to handle creation of data stores for a single application.
- Added a DataStore to handle the management of mediator topics related to a single resource.